### PR TITLE
Fix require options on case-sensitive operating systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aws-cloudformation-simple-cli",
   "author": "carl@bynordenfelt.se",
   "description": "A simple command line tool for managing CloudFormation stacks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "preferGlobal": true,
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 /* istanbul ignore next */
-var Options = require('./lib/Options');
+var Options = require('./lib/options');
 /* istanbul ignore next */
 var commands = require('./lib/commands');
 /* istanbul ignore next */


### PR DESCRIPTION
`src/index.js` was requiring `./lib/Options` when the actual file was `./lib/options.js`.  This was working on a case insensitive OS like Windows, but failing with the following error on `Amazon Linux AMI release 2016.09`

```
module.js:327
    throw err;
    ^

Error: Cannot find module './lib/Options'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/ec2-user/node_modules/aws-cloudformation-simple-cli/src/index.js:5:15)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
```
